### PR TITLE
Image from rss feed

### DIFF
--- a/Protocol/Item.php
+++ b/Protocol/Item.php
@@ -152,7 +152,7 @@ class Item
      * @return \Debril\RssAtomBundle\Protocol\Item
      */
     public function setImage($image)
-    {
+	{
         $this->image = $image;
 
         return $this;

--- a/Protocol/Parser/RssParser.php
+++ b/Protocol/Parser/RssParser.php
@@ -37,7 +37,8 @@ class RssParser extends Parser
      * @param \DateTime $modifiedSince
      * @return \Debril\RssAtomBundle\Protocol\FeedContent
      */
-    protected function parseBody( SimpleXMLElement $xmlBody, \DateTime $modifiedSince ) {
+    protected function parseBody( SimpleXMLElement $xmlBody, \DateTime $modifiedSince ) 
+	{
         $feedContent = new FeedContent();
 
         $feedContent->setId($xmlBody->channel->link);


### PR DESCRIPTION
I've customized the RSSParser and Item classes in order to load the item's image from the feed.

Also I've made it a bit more robust so that it doesn't fall over when the channel's last build date is not populated.
