### PR TITLE
Update DebrilRssAtomExtension.php

### DIFF
--- a/DependencyInjection/DebrilRssAtomExtension.php
+++ b/DependencyInjection/DebrilRssAtomExtension.php
@@ -30,6 +30,7 @@ class DebrilRssAtomExtension extends Extension
             \DateTime::RFC3339,
             \DateTime::RSS,
             \DateTime::W3C,
+            'Y-m-d\TH:i:s.uP',
             'Y-m-d',
         );
 


### PR DESCRIPTION
I tried to read google blog http://blog.symfony.spb.ru/feeds/posts/default and I got problem because  date format is 2013-07-21T15:21:38.267+03:00. As google blogger is quite popular I think we shall add this date pattern to default array.  It's related this https://github.com/alexdebril/rss-atom-bundle/issues/21 issue.
