### PR TITLE
Fix Atom Parsing date guessing

### DIFF
--- a/Protocol/Parser/AtomParser.php
+++ b/Protocol/Parser/AtomParser.php
@@ -65,12 +65,14 @@ class AtomParser extends Parser
 
         foreach ($xmlBody->entry as $xmlElement)
         {
+            $itemFormat = isset($itemFormat) ? $itemFormat : $this->guessDateFormat($xmlElement->updated);
+
             $item = $this->newItem();
             $item->setTitle($xmlElement->title)
                     ->setPublicId($xmlElement->id)
                     ->setSummary($xmlElement->summary)
                     ->setDescription($this->parseContent($xmlElement->content))
-                    ->setUpdated(self::convertToDateTime($xmlElement->updated, $format));
+                    ->setUpdated(self::convertToDateTime($xmlElement->updated, $itemFormat));
 
             $item->setLink($this->detectLink($xmlElement, 'alternate'));
 


### PR DESCRIPTION
When trying to parse an atom feed where the dates are different in the feed object and on the actual entries, the processing would fail as it was expecting the formats to be the same.

This pull request fixes that issue.

For example:

```
<?xml version="1.0" encoding="utf-8"?>
<feed xmlns="http://www.w3.org/2005/Atom" xmlns:pa="http://rss.example.com">
    <link href="http://rss.example.com/feed/atom.xml" rel="self" />
    <title>Example Feed</title>
    <updated>2013-10-14T08:47:04.630Z</updated>
    <id>urn:feed:example.com:20131014:7662773713407339981</id>
    <entry>
            <title>Entry Title</title>
            <author>
                <name>The Press Association</name>
            </author>
            <id>urn:feed:example.com:20131014:969648fe-4028-404d-a3cf-087eb7c3fda1</id>
            <updated>2013-10-14T08:46:47Z</updated>
```

**Only an excerpt of XML is shown**

Trying to parse this with the current version fails because the date formats aren't the same. This is fixed in the PR.
