### PR TITLE
added support for additional namespaced elements

### DIFF
--- a/Protocol/Parser.php
+++ b/Protocol/Parser.php
@@ -68,6 +68,8 @@ abstract class Parser
 
         $this->checkBodyStructure($xmlBody);
 
+        $xmlBody = $this->registerNamespaces($xmlBody);
+
         return $this->parseBody($xmlBody, $feed, $filters);
     }
 
@@ -92,7 +94,7 @@ abstract class Parser
         {
             $report = implode(", ", $errors);
             throw new ParserException(
-            "error while parsing the feed : {$report}"
+                "error while parsing the feed : {$report}"
             );
         }
     }
@@ -248,6 +250,40 @@ abstract class Parser
     }
 
     /**
+     * register Namespaces
+     *
+     * @param SimpleXMLElement $xmlBody
+     * @return SimpleXMLElement
+     */
+    protected function registerNamespaces(SimpleXMLElement $xmlBody){
+        $namespaces = $xmlBody->getNamespaces(true);
+        foreach ($namespaces as $prefix => $ns) {
+            if($prefix != ''){
+                $xmlBody->registerXPathNamespace($prefix, $ns);
+            }
+        }
+        return $xmlBody;
+    }
+
+    /**
+     * @param SimpleXMLElement $xmlElement
+     * @param $namespaces
+     * @return array
+     */
+    protected function getAdditionalNamespacesElements(SimpleXMLElement $xmlElement, $namespaces){
+        $additional = array();
+        foreach ($namespaces as $prefix => $ns) {
+            if($prefix != ''){
+                $additionalElement = $xmlElement->children($ns);
+                if(!empty($additionalElement)){
+                    $additional[$prefix] = $additionalElement;
+                }
+            }
+        }
+        return $additional;
+    }
+
+    /**
      * Tells if the parser can handle the feed or not
      *
      * @param  SimpleXMLElement $xmlBody
@@ -265,4 +301,3 @@ abstract class Parser
      */
     abstract protected function parseBody(SimpleXMLElement $body, FeedInterface $feed, array $filters);
 }
-

--- a/Protocol/Parser/AtomParser.php
+++ b/Protocol/Parser/AtomParser.php
@@ -55,6 +55,8 @@ class AtomParser extends Parser
     {
         $this->parseHeaders($xmlBody, $feed);
 
+        $namespaces = $xmlBody->getNamespaces(true);
+
         foreach ($xmlBody->entry as $xmlElement)
         {
             $itemFormat = isset($itemFormat) ? $itemFormat : $this->guessDateFormat($xmlElement->updated);
@@ -72,6 +74,9 @@ class AtomParser extends Parser
             {
                 $item->setAuthor($xmlElement->author->name);
             }
+
+
+            $item->setAdditional($this->getAdditionalNamespacesElements($xmlElement, $namespaces));
 
             $this->addValidItem($feed, $item, $filters);
         }

--- a/Protocol/Parser/Item.php
+++ b/Protocol/Parser/Item.php
@@ -74,6 +74,13 @@ class Item implements ItemIn, ItemOut
     protected $comment;
 
     /**
+     * this will take all additional elements from other namespace as array with raw simpleXml
+     * f.e. MediaRss or FeedBurner additions
+     * @var array
+     */
+    protected $additional;
+
+    /**
      * Atom : feed.entry.title <feed><entry><title>
      * Rss  : rss.channel.item.title <rss><channel><item><title>
      * @return string
@@ -252,5 +259,29 @@ class Item implements ItemIn, ItemOut
 
         return $this;
     }
+
+    /**
+     * this will take all additional elements from other namespace as array with raw simpleXml
+     * f.e. MediaRss or FeedBurner additions
+     *
+     * @param array $additional
+     */
+    public function setAdditional(array $additional)
+    {
+        $this->additional = $additional;
+    }
+
+    /**
+     * this will take all additional elements from other namespace as array with raw simpleXml
+     * f.e. MediaRss or FeedBurner additions
+     *
+     * @return array
+     */
+    public function getAdditional()
+    {
+        return $this->additional;
+    }
+
+
 
 }

--- a/Protocol/Parser/RssParser.php
+++ b/Protocol/Parser/RssParser.php
@@ -49,6 +49,8 @@ class RssParser extends Parser
      */
     protected function parseBody(SimpleXMLElement $xmlBody, FeedInterface $feed, array $filters)
     {
+        $namespaces = $xmlBody->getNamespaces(true);
+
         $feed->setPublicId($xmlBody->channel->link);
         $feed->setLink($xmlBody->channel->link);
         $feed->setTitle($xmlBody->channel->title);
@@ -65,17 +67,19 @@ class RssParser extends Parser
                 $date = self::convertToDateTime($xmlElement->pubDate, $format);
             }
             $item->setTitle($xmlElement->title)
-                    ->setDescription($xmlElement->description)
-                    ->setPublicId($xmlElement->guid)
-                    ->setUpdated($date)
-                    ->setLink($xmlElement->link)
-                    ->setComment($xmlElement->comments)
-                    ->setAuthor($xmlElement->author);
+                 ->setDescription($xmlElement->description)
+                 ->setPublicId($xmlElement->guid)
+                 ->setUpdated($date)
+                 ->setLink($xmlElement->link)
+                 ->setComment($xmlElement->comments)
+                 ->setAuthor($xmlElement->author);
 
             if ($date > $latest)
             {
                 $latest = $date;
             }
+
+            $item->setAdditional($this->getAdditionalNamespacesElements($xmlElement, $namespaces));
 
             $this->addValidItem($feed, $item, $filters);
         }

--- a/Resources/sample-atom-namespaced.xml
+++ b/Resources/sample-atom-namespaced.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:feedburner="http://rssnamespace.org/feedburner/ext/1.0">
+
+    <title>Example Feed</title>
+    <subtitle>A subtitle.</subtitle>
+    <link href="http://example.org/feed/" rel="self" />
+    <link href="http://example.org/" />
+    <id>urn:uuid:60a76c80-d399-11d9-b91C-0003939e0af6</id>
+    <updated>2003-12-13T18:30:02Z</updated>
+
+
+    <entry>
+        <title>Atom-Powered Robots Run Amok</title>
+        <link href="http://example.org/2003/12/13/atom03" />
+        <link rel="alternate" type="text/html" href="http://example.org/2003/12/13/atom03.html"/>
+        <link rel="edit" href="http://example.org/2003/12/13/atom03/edit"/>
+        <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+        <updated>2003-12-13T18:30:02Z</updated>
+        <content type="xhtml">
+            <div>A title</div>
+            <p>A paragraph</p>
+        </content>
+        <author>
+            <name>John Doe</name>
+            <email>johndoe@example.com</email>
+            <uri>http://johndoe.com</uri>
+        </author>
+        <feedburner:origLink>http://original-link.com/item.html</feedburner:origLink>
+    </entry>
+
+    <entry>
+        <title>A partial entry</title>
+        <link href="http://example.org/2003/12/13/atom03" />
+        <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+        <updated>2003-12-13T18:30:02Z</updated>
+        <content type="xhtml">
+            <div>A title</div>
+            <p>A paragraph</p>
+        </content>
+    </entry>
+
+</feed>

--- a/Resources/sample-rss-media.xml
+++ b/Resources/sample-rss-media.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+    <channel>
+        <title>RSS Title</title>
+        <description>This is an example of an RSS feed</description>
+        <link>http://www.someexamplerssdomain.com/main.html</link>
+        <lastBuildDate>Mon, 06 Sep 2010 00:01:00 GMT</lastBuildDate>
+        <pubDate>Mon, 06 Sep 2009 16:45:00 GMT</pubDate>
+        <ttl>1800</ttl>
+
+        <item>
+            <title>Example entry</title>
+            <description>Here is some text containing an interesting description.</description>
+            <link>http://www.wikipedia.org/</link>
+            <guid>unique string per item</guid>
+            <pubDate>Mon, 06 Sep 2009 16:45:00 GMT</pubDate>
+            <author>John Doe</author>
+            <media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="http://media-server.com/image.jpg" height="72" width="72"/>
+        </item>
+
+    </channel>
+</rss>

--- a/Tests/Protocol/FeedReaderTest.php
+++ b/Tests/Protocol/FeedReaderTest.php
@@ -142,6 +142,35 @@ class FeedReaderTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Debril\RssAtomBundle\Protocol\FeedReader::parseBody
      */
+    public function testAdditionalNamespacedElements()
+    {
+        $url = dirname(__FILE__) . '/../../Resources/sample-atom-namespaced.xml';
+        $this->object->addParser(new Parser\AtomParser);
+        $response = $this->object->getResponse($url, new \DateTime);
+        $feed = $this->object->parseBody($response, new Parser\FeedContent);
+        $items = $feed->getItems();
+        $additional = $items[0]->getAdditional();
+        $this->assertEquals('http://original-link.com/item.html', $additional['feedburner']->origLink);
+    }
+
+    /**
+     * @covers Debril\RssAtomBundle\Protocol\FeedReader::parseBody
+     */
+    public function testRssAdditionalNamespacedElements()
+    {
+        $url = dirname(__FILE__) . '/../../Resources/sample-rss-media.xml';
+        $this->object->addParser(new Parser\RssParser());
+        $response = $this->object->getResponse($url, new \DateTime);
+        $feed = $this->object->parseBody($response, new Parser\FeedContent);
+        $items = $feed->getItems();
+        $additional = $items[0]->getAdditional();
+        $additionalAttributes = $additional['media']->thumbnail->attributes();
+        $this->assertEquals('http://media-server.com/image.jpg', $additionalAttributes['url']);
+    }
+
+    /**
+     * @covers Debril\RssAtomBundle\Protocol\FeedReader::parseBody
+     */
     public function testParseBody()
     {
         $url = dirname(__FILE__) . '/../../Resources/sample-rss.xml';

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "phpunit/phpunit": "~3.7",
         "doctrine/common": "~2.3",
-	"symfony/framework-bundle": "~2.3",
+        "symfony/framework-bundle": "~2.3",
         "symfony/finder": "~2.3",
         "symfony/form": "~2.3",
         "symfony/browser-kit": "~2.3"


### PR DESCRIPTION
i eventually made a pull request to provide support for namespaced elements like feedreader or media items.
this refers to https://github.com/alexdebril/rss-atom-bundle/issues/29

not sure how far you came with your approach, but in the meantime we could use this, if you dont mind.
