### PR TITLE
Tweaked composer requirement doc in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Compatibility between 1.1.6 and 1.2.0
 
 If you are already using rss-atom-bundle, beware that the 1.2.0 version breaks some backward compatibility. If you do not need the improvements provided by the 1.2.0 version, please edit composer.json as below :
 
-    "debril/rss-atom-bundle": "~1.1, <1.2"
+    "debril/rss-atom-bundle": "~1.1.0"
 
 The migration process is described in the [migrations section](https://github.com/alexdebril/rss-atom-bundle/wiki/Migrations)
 


### PR DESCRIPTION
~1.1.0 is a shortcut for ~1.1, <1.2
