### PR TITLE
Fix Issue #49

### DIFF
--- a/Protocol/Parser/AtomParser.php
+++ b/Protocol/Parser/AtomParser.php
@@ -68,7 +68,7 @@ class AtomParser extends Parser
             $item = $this->newItem();
             $item->setTitle($xmlElement->title)
                     ->setPublicId($xmlElement->id)
-                    ->setSummary($xmlElement->summary)
+                    ->setSummary($this->parseContent($xmlElement->summary))
                     ->setDescription($this->parseContent($xmlElement->content))
                     ->setUpdated(self::convertToDateTime($xmlElement->updated, $itemFormat));
 
@@ -123,7 +123,7 @@ class AtomParser extends Parser
 
     protected function parseContent(SimpleXMLElement $content)
     {
-        if (0 < $content->children()->count()) {
+        if ($content && 0 < $content->children()->count()) {
             $out = '';
             foreach ($content->children() as $child) {
                 $out .= $child->asXML();

--- a/Resources/sample-atom-summary.xml
+++ b/Resources/sample-atom-summary.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title>Some Blog</title>
+    <updated>2015-03-08T16:46:32Z</updated>
+    <author>
+        <name>Some Name</name>
+        <email>email@example.com</email>
+    </author>
+    <id>http://example.com/atom.xml</id>
+    <link href="http://example.com/atom.xml" rel="self" type="application/atom+xml"/>
+    <link href="http://example.com/" rel="alternate"/>
+
+    <entry>
+        <id>http://example.com/some-posting/</id>
+        <link href="http://example.com/some-posting/" rel="alternate" type="text/html"/>
+        <title>Awesome Title</title>
+        <summary type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><p>sample text</p></div></summary>
+        <updated>2015-03-01T08:00:00Z</updated>
+        <author>
+            <name>John Doe</name>
+            <email>johndoe@example.com</email>
+            <uri>http://johndoe.com</uri>
+        </author>
+    </entry>
+</feed>

--- a/Tests/Protocol/Parser/AtomParserTest.php
+++ b/Tests/Protocol/Parser/AtomParserTest.php
@@ -142,4 +142,23 @@ class AtomParserTest extends ParserAbstract
         $this->assertTrue(strlen($item->getDescription()) > 0);
     }
 
+    /**
+     *
+     */
+    public function testHtmlSummary()
+    {
+        $file = dirname(__FILE__) . '/../../../Resources/sample-atom-summary.xml';
+        $xmlBody = new \SimpleXMLElement(file_get_contents($file));
+
+        $date = \DateTime::createFromFormat("Y-m-d", "2002-10-10");
+        $filters = array(new \Debril\RssAtomBundle\Protocol\Filter\ModifiedSince($date));
+        $feed = $this->object->parse($xmlBody, new FeedContent(), $filters);
+
+        $this->assertInstanceOf("Debril\RssAtomBundle\Protocol\FeedIn", $feed);
+        $item = current($feed->getItems());
+
+        $expected = '<div xmlns="http://www.w3.org/1999/xhtml"><p>sample text</p></div>';
+        $this->assertEquals($expected, $item->getSummary());
+    }
+
 }


### PR DESCRIPTION
As described in Issue #49, I get a PHP Warning from SimpleXML when parsing the Atom feed http://planet.mozilla.org/atom.xml (but the problem should be independent of the feed). 

The patch fixes the issue for me.