### PR TITLE
Fix deprecated routing configuration

### DIFF
--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -4,24 +4,24 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="feed_stream" pattern="/stream/{id}">
+    <route id="feed_stream" path="/stream/{id}">
         <default key="_controller">DebrilRssAtomBundle:Stream:index</default>
         <default key="id">null</default>
     </route>
 
-    <route id="feed_atom" pattern="/atom/{id}">
+    <route id="feed_atom" path="/atom/{id}">
         <default key="_controller">DebrilRssAtomBundle:Stream:index</default>
         <default key="format">atom</default>
         <default key="id">null</default>
     </route>
 
-    <route id="feed_rss" pattern="/rss/{id}">
+    <route id="feed_rss" path="/rss/{id}">
         <default key="_controller">DebrilRssAtomBundle:Stream:index</default>
         <default key="format">rss</default>
         <default key="id">null</default>
     </route>
 
-    <route id="mock_feed_rss" pattern="/mock/rss/{id}">
+    <route id="mock_feed_rss" path="/mock/rss/{id}">
         <default key="_controller">DebrilRssAtomBundle:Stream:index</default>
         <default key="format">rss</default>
         <default key="source">debril.provider.mock</default>

--- a/Tests/Controller/App/routing.xml
+++ b/Tests/Controller/App/routing.xml
@@ -4,14 +4,14 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="debril_rss_atom_mock_rss" pattern="/mock/rss/{id}">
+    <route id="debril_rss_atom_mock_rss" path="/mock/rss/{id}">
         <default key="_controller">DebrilRssAtomBundle:Stream:index</default>
         <default key="format">rss</default>
         <default key="source">debril.provider.mock</default>
         <default key="id">null</default>
     </route>
 
-    <route id="debril_rss_atom_bad_provider" pattern="/bad/provider">
+    <route id="debril_rss_atom_bad_provider" path="/bad/provider">
         <default key="_controller">DebrilRssAtomBundle:Stream:index</default>
         <default key="format">rss</default>
         <default key="source">debril.parser.rss</default>


### PR DESCRIPTION
This PR fix deprecated routing config throwing related errors:

> The "pattern" is deprecated since version 2.2 and will be removed in 3.0. Use the "path" option in the route definition instead.
