### PR TITLE
Common exception classes

### DIFF
--- a/Driver/DriverUnreachableResourceException.php
+++ b/Driver/DriverUnreachableResourceException.php
@@ -7,12 +7,14 @@
  * @license http://opensource.org/licenses/lgpl-3.0.html LGPL
  * @copyright (c) 2013, Alexandre Debril
  */
+
 namespace Debril\RssAtomBundle\Driver;
+
+use Debril\RssAtomBundle\Exception\RssAtomException;
 
 /**
  * Class DriverUnreachableResourceException.
  */
-class DriverUnreachableResourceException extends \Exception
+class DriverUnreachableResourceException extends RssAtomException
 {
-    //put your code here
 }

--- a/Exception/FeedException.php
+++ b/Exception/FeedException.php
@@ -11,8 +11,10 @@
 namespace Debril\RssAtomBundle\Exception;
 
 /**
- * Class FeedCannotBeReadException.
+ * Class FeedException.
+ *
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-class FeedCannotBeReadException extends FeedException
+class FeedException extends RssAtomException
 {
 }

--- a/Exception/FeedForbiddenException.php
+++ b/Exception/FeedForbiddenException.php
@@ -7,11 +7,12 @@
  * @license http://opensource.org/licenses/lgpl-3.0.html LGPL
  * @copyright (c) 2013, Alexandre Debril
  */
+
 namespace Debril\RssAtomBundle\Exception;
 
 /**
  * Class FeedForbiddenException.
  */
-class FeedForbiddenException extends \Exception
+class FeedForbiddenException extends FeedException
 {
 }

--- a/Exception/FeedNotFoundException.php
+++ b/Exception/FeedNotFoundException.php
@@ -7,11 +7,12 @@
  * @license http://opensource.org/licenses/lgpl-3.0.html LGPL
  * @copyright (c) 2013, Alexandre Debril
  */
+
 namespace Debril\RssAtomBundle\Exception;
 
 /**
  * Class FeedNotFoundException.
  */
-class FeedNotFoundException extends \Exception
+class FeedNotFoundException extends FeedException
 {
 }

--- a/Exception/FeedNotModifiedException.php
+++ b/Exception/FeedNotModifiedException.php
@@ -7,11 +7,12 @@
  * @license http://opensource.org/licenses/lgpl-3.0.html LGPL
  * @copyright (c) 2013, Alexandre Debril
  */
+
 namespace Debril\RssAtomBundle\Exception;
 
 /**
  * Class FeedNotModifiedException.
  */
-class FeedNotModifiedException extends \Exception
+class FeedNotModifiedException extends FeedException
 {
 }

--- a/Exception/FeedServerErrorException.php
+++ b/Exception/FeedServerErrorException.php
@@ -7,11 +7,12 @@
  * @license http://opensource.org/licenses/lgpl-3.0.html LGPL
  * @copyright (c) 2013, Alexandre Debril
  */
+
 namespace Debril\RssAtomBundle\Exception;
 
 /**
  * Class FeedServerErrorException.
  */
-class FeedServerErrorException extends \Exception
+class FeedServerErrorException extends FeedException
 {
 }

--- a/Exception/RssAtomException.php
+++ b/Exception/RssAtomException.php
@@ -11,8 +11,10 @@
 namespace Debril\RssAtomBundle\Exception;
 
 /**
- * Class FeedCannotBeReadException.
+ * Class RssAtomException.
+ *
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-class FeedCannotBeReadException extends FeedException
+class RssAtomException extends \RuntimeException
 {
 }

--- a/Protocol/Parser/ParserException.php
+++ b/Protocol/Parser/ParserException.php
@@ -7,11 +7,14 @@
  * @license http://opensource.org/licenses/lgpl-3.0.html LGPL
  * @copyright (c) 2013, Alexandre Debril
  */
+
 namespace Debril\RssAtomBundle\Protocol\Parser;
+
+use Debril\RssAtomBundle\Exception\RssAtomException;
 
 /**
  * Class ParserException.
  */
-class ParserException extends \Exception
+class ParserException extends RssAtomException
 {
 }


### PR DESCRIPTION
Introducing `RssAtomException` and `FeedException` classes.

The rules: 

 * All exceptions related to feed should extends `FeedException`.
 * All another bundle exceptions should extends `RssAtomException`.

This permit to handle multiple kind of Exception thrown by this bundle with ease.

Sample 1:

```php
$feed = new FeedReader();
try {
    $feed = $feedReader->getFeedContent($source->getRssUrl(), $source->getRefreshedAt());
} catch (FeedException $e) { // Take only exceptions related to feeds
    // Do something whit it.
}
```

Sample 2:

```php
$feed = new FeedReader();
try {
    $feed = $feedReader->getFeedContent($source->getRssUrl(), $source->getRefreshedAt());
} catch (RssAtomException $e) { // Take all exceptions related to this bundle
    // Do something whit it.
}
```

`RssAtomException` extends PHP `RuntimeException` that make more sense IMO.

This PR provide no BC breaks and could be bumped to a new minor version (e.g. `1.8`)

I think exceptions directory structure should be reviewed to mode all exception on the `Exception` folder to get more clean and organized code.

But this will be BC break. I will make another PR about that for a major version if this one is accepted.

Regards.