### PR TITLE
Packagist branch-alias option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,10 @@
     "target-dir": "Debril/RssAtomBundle",
     "config": {
         "bin-dir": "bin"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
This option permit to specify on packagist which version is on development for the current branch.

This should be added and updated and every minor branch.

For a concrete application sample, see my project:

 * packagist: https://packagist.org/packages/sllh/iso-codes-validator
 * project: https://github.com/Soullivaneuh/IsoCodesValidator

Regards.