### PR TITLE
Added media support

### DIFF
--- a/Protocol/Formatter/FeedAtomFormatter.php
+++ b/Protocol/Formatter/FeedAtomFormatter.php
@@ -51,7 +51,7 @@ class FeedAtomFormatter extends FeedFormatter
      */
     public function setMetas(\DOMDocument $document, FeedOutInterface $content)
     {
-        $elements = [];
+        $elements = array();
         $elements[] = $document->createElement('title', htmlspecialchars($content->getTitle()));
         $elements[] = $document->createElement('subtitle', $content->getDescription());
         $elements[] = $document->createElement('id', $content->getLink());
@@ -76,7 +76,7 @@ class FeedAtomFormatter extends FeedFormatter
     {
         $entry = $document->createElement('entry');
 
-        $elements = [];
+        $elements = array();
         $elements[] = $document->createElement('title', htmlspecialchars($item->getTitle()));
 
         $link = $document->createElement('link');

--- a/Protocol/Formatter/FeedAtomFormatter.php
+++ b/Protocol/Formatter/FeedAtomFormatter.php
@@ -110,16 +110,14 @@ class FeedAtomFormatter extends FeedFormatter
             $elements[] = $author;
         }
 
-        if (0 !== count($item->getMedias())) { // Doctrine ArrayCollection do not support empty()
-            foreach ($item->getMedias() as $media) {
-                $mediaLink = $document->createElement('link');
-                $mediaLink->setAttribute('rel', 'enclosure');
-                $mediaLink->setAttribute('href', $media->getUrl());
-                $mediaLink->setAttribute('length', $media->getLength());
-                $mediaLink->setAttribute('type', $media->getType());
+        foreach ($item->getMedias() as $media) {
+            $mediaLink = $document->createElement('link');
+            $mediaLink->setAttribute('rel', 'enclosure');
+            $mediaLink->setAttribute('href', $media->getUrl());
+            $mediaLink->setAttribute('length', $media->getLength());
+            $mediaLink->setAttribute('type', $media->getType());
 
-                $elements[] = $mediaLink;
-            }
+            $elements[] = $mediaLink;
         }
 
         foreach ($elements as $element) {

--- a/Protocol/Formatter/FeedAtomFormatter.php
+++ b/Protocol/Formatter/FeedAtomFormatter.php
@@ -51,7 +51,7 @@ class FeedAtomFormatter extends FeedFormatter
      */
     public function setMetas(\DOMDocument $document, FeedOutInterface $content)
     {
-        $elements = array();
+        $elements = [];
         $elements[] = $document->createElement('title', htmlspecialchars($content->getTitle()));
         $elements[] = $document->createElement('subtitle', $content->getDescription());
         $elements[] = $document->createElement('id', $content->getLink());
@@ -76,7 +76,7 @@ class FeedAtomFormatter extends FeedFormatter
     {
         $entry = $document->createElement('entry');
 
-        $elements = array();
+        $elements = [];
         $elements[] = $document->createElement('title', htmlspecialchars($item->getTitle()));
 
         $link = $document->createElement('link');
@@ -108,6 +108,18 @@ class FeedAtomFormatter extends FeedFormatter
             $author->appendChild($document->createElement('name', $item->getAuthor()));
 
             $elements[] = $author;
+        }
+
+        if (0 !== count($item->getMedias())) { // Doctrine ArrayCollection do not support empty()
+            foreach ($item->getMedias() as $media) {
+                $mediaLink = $document->createElement('link');
+                $mediaLink->setAttribute('rel', 'enclosure');
+                $mediaLink->setAttribute('href', $media->getUrl());
+                $mediaLink->setAttribute('length', $media->getLength());
+                $mediaLink->setAttribute('type', $media->getType());
+
+                $elements[] = $mediaLink;
+            }
         }
 
         foreach ($elements as $element) {

--- a/Protocol/Formatter/FeedRssFormatter.php
+++ b/Protocol/Formatter/FeedRssFormatter.php
@@ -71,6 +71,32 @@ class FeedRssFormatter extends FeedFormatter
         $elements[] = $document->createElement('comments', $item->getComment());
         $elements[] = $document->createElement('description', htmlspecialchars($item->getDescription(), ENT_COMPAT, 'UTF-8'));
 
+        if (0 !== count($item->getMedias())) { // Doctrine ArrayCollection do not support empty()
+            $n = 0;
+
+            foreach ($item->getMedias() as $media) {
+                // We can have only one enclosure in RSS 2.0
+                // We use as a fallback Yahoo RSS Media extension
+                if (1 === $n) {
+                    $mediaElement = $document->createElement('enclosure');
+                    $mediaElement->setAttribute('url', $media->getUrl());
+                    $mediaElement->setAttribute('length', $media->getLength());
+                    $mediaElement->setAttribute('type', $media->getType());
+                }
+
+                $mediaElement = $document->createElement('media:content');
+                $mediaElement->setAttribute('url', $media->getUrl());
+                $mediaElement->setAttribute('fileSize', $media->getLength());
+                $mediaElement->setAttribute('type', $media->getType());
+                $mediaElement->setAttribute('xmlns:media', 'http://search.yahoo.com/mrss/');
+
+
+                $elements[] = $mediaElement;
+
+                $n++;
+            }
+        }
+
         if (!is_null($item->getAuthor())) {
             $elements[] = $document->createElement('author', $item->getAuthor());
         }

--- a/Protocol/Formatter/FeedRssFormatter.php
+++ b/Protocol/Formatter/FeedRssFormatter.php
@@ -71,30 +71,27 @@ class FeedRssFormatter extends FeedFormatter
         $elements[] = $document->createElement('comments', $item->getComment());
         $elements[] = $document->createElement('description', htmlspecialchars($item->getDescription(), ENT_COMPAT, 'UTF-8'));
 
-        if (0 !== count($item->getMedias())) { // Doctrine ArrayCollection do not support empty()
-            $n = 0;
-
-            foreach ($item->getMedias() as $media) {
-                // We can have only one enclosure in RSS 2.0
-                // We use as a fallback Yahoo RSS Media extension
-                if (1 === $n) {
-                    $mediaElement = $document->createElement('enclosure');
-                    $mediaElement->setAttribute('url', $media->getUrl());
-                    $mediaElement->setAttribute('length', $media->getLength());
-                    $mediaElement->setAttribute('type', $media->getType());
-                }
-
-                $mediaElement = $document->createElement('media:content');
+        $mediaCount = 0;
+        foreach ($item->getMedias() as $media) {
+            // We can have only one enclosure in RSS 2.0
+            // We use as a fallback Yahoo RSS Media extension
+            if (1 === $mediaCount) {
+                $mediaElement = $document->createElement('enclosure');
                 $mediaElement->setAttribute('url', $media->getUrl());
-                $mediaElement->setAttribute('fileSize', $media->getLength());
+                $mediaElement->setAttribute('length', $media->getLength());
                 $mediaElement->setAttribute('type', $media->getType());
-                $mediaElement->setAttribute('xmlns:media', 'http://search.yahoo.com/mrss/');
-
-
-                $elements[] = $mediaElement;
-
-                $n++;
             }
+
+            $mediaElement = $document->createElement('media:content');
+            $mediaElement->setAttribute('url', $media->getUrl());
+            $mediaElement->setAttribute('fileSize', $media->getLength());
+            $mediaElement->setAttribute('type', $media->getType());
+            $mediaElement->setAttribute('xmlns:media', 'http://search.yahoo.com/mrss/');
+
+
+            $elements[] = $mediaElement;
+
+            $mediaCount++;
         }
 
         if (!is_null($item->getAuthor())) {

--- a/Protocol/Formatter/FeedRssFormatter.php
+++ b/Protocol/Formatter/FeedRssFormatter.php
@@ -75,7 +75,7 @@ class FeedRssFormatter extends FeedFormatter
         foreach ($item->getMedias() as $media) {
             // We can have only one enclosure in RSS 2.0
             // We use as a fallback Yahoo RSS Media extension
-            if (1 === $mediaCount) {
+            if (0 === $mediaCount) {
                 $mediaElement = $document->createElement('enclosure');
                 $mediaElement->setAttribute('url', $media->getUrl());
                 $mediaElement->setAttribute('length', $media->getLength());

--- a/Protocol/ItemOutInterface.php
+++ b/Protocol/ItemOutInterface.php
@@ -81,9 +81,9 @@ interface ItemOutInterface
     public function getComment();
 
     /**
-     * Rss  : rss.channel.item.enclosure <rss><channel><item><enclosure>.
+     * Rss  : rss.channel.item.enclosure for the first one <rss><channel><item><enclosure>, and rss.channel.item.media:content <rss><channel><item><media:content> for all media
      *
-     * @return \ArrayIterator $medias
+     * @return \ArrayIterator|MediaOutInterface[] $medias
      */
     public function getMedias();
 }

--- a/Protocol/MediaOutInterface.php
+++ b/Protocol/MediaOutInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Debril\RssAtomBundle\Protocol;
+
+/**
+ * Interface MediaOutInterface
+ */
+interface MediaOutInterface
+{
+    /**
+     * Rss  : rss.entry.media:content url attribute
+     *
+     * @return string
+     */
+    public function getUrl();
+
+    /**
+     * Rss  : rss.entry.media:content type attribute
+     *
+     * @return string mime type
+     */
+    public function getType();
+
+    /**
+     * Rss  : rss.entry.media:content fileSize attribute
+     *
+     * @return integer fle size or 0 if unknown
+     */
+    public function getLength();
+}

--- a/Protocol/Parser/Media.php
+++ b/Protocol/Parser/Media.php
@@ -25,7 +25,7 @@ class Media
     protected $url;
 
     /**
-     * @var int
+     * @var int with a legacy typo :)
      */
     protected $lenght;
 
@@ -85,6 +85,26 @@ class Media
     public function setLenght($lenght)
     {
         $this->lenght = intval($lenght);
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLength()
+    {
+        return $this->lenght;
+    }
+
+    /**
+     * @param string $length
+     *
+     * @return $this
+     */
+    public function setLength($length)
+    {
+        $this->lenght = intval($length);
 
         return $this;
     }

--- a/Tests/Protocol/FormatterAbstract.php
+++ b/Tests/Protocol/FormatterAbstract.php
@@ -10,6 +10,7 @@ namespace Debril\RssAtomBundle\Tests\Protocol;
 
 use Debril\RssAtomBundle\Protocol\Parser\FeedContent;
 use Debril\RssAtomBundle\Protocol\Parser\Item;
+use Debril\RssAtomBundle\Protocol\Parser\Media;
 
 class FormatterAbstract extends \PHPUnit_Framework_TestCase
 {
@@ -36,6 +37,12 @@ class FormatterAbstract extends \PHPUnit_Framework_TestCase
         $item->setUpdated(new \DateTime());
         $item->setComment('http://linktothecomments.com');
         $item->setAuthor('Contributor');
+
+        $media = new Media();
+        $media->setUrl('http://media');
+        $media->setUrl('image/jpeg');
+
+        $item->addMedia($media);
 
         $this->feed->addItem($item);
     }


### PR DESCRIPTION
Hi,

After #70 I figured out I could work on that one :)

So that one adds Media support for Atom and RSS feeds.
Atom compatibility is pretty straightforward; for RSS, you can have only one `enclosure` in RSS 2.0. You also have Yahoo RSS Media you can use, but it is an extension of the spec.
So my choice was to dump first found media as both a Yahoo RSS media and an enclosure, so everybody can read it, and after to use only Yahoo RSS media.

By the way, there is a typo in `Parser/Media`. Accessors are `getLenght/setLenght` instead of `getLength/setLength`. I added the correct ones, without removing the old ones for BC. But since you just tagged 2.0, maybe we can remove those?