### PR TITLE
Fixed typo in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Then add the bundle's routing configuration in app/config/routing.yml :
  
 ```yaml
 feedio:
-    resource: @DebrilRssAtomBundle/Resources/config/routing.yml
+    resource: @DebrilRssAtomBundle/Resources/config/routing.xml
 
 ```
 


### PR DESCRIPTION
There was a typo in installations instructions: the routing file is a XML file, not YML.
