### PR TITLE
Private feeds

### DIFF
--- a/Controller/StreamController.php
+++ b/Controller/StreamController.php
@@ -94,7 +94,10 @@ class StreamController extends Controller
             $response = new Response($formatter->toString($content));
             $response->headers->set('Content-Type', 'application/xhtml+xml');
 
-            $response->setPublic();
+            if (! $this->container->getParameter('debril_rss_atom.private_feeds')) {
+                $response->setPublic();
+            }
+
             $response->setMaxAge(3600);
             $response->setLastModified($content->getLastModified());
         } else {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,12 +18,18 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('debril_rss_atom');
-        $rootNode
+
+        $treeBuilder->root('debril_rss_atom')
                 ->children()
-                ->arrayNode('date_formats')
-                ->prototype('scalar')->end()
-                ->end();
+                    ->booleanNode('private')
+                        ->info('Change cache headers so the RSS feed is not cached by public caches (like reverse-proxies...).')
+                        ->defaultValue(false)
+                    ->end()
+                    ->arrayNode('date_formats')
+                        ->prototype('scalar')->end()
+                    ->end()
+                ->end()
+        ;
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for

--- a/DependencyInjection/DebrilRssAtomExtension.php
+++ b/DependencyInjection/DebrilRssAtomExtension.php
@@ -43,5 +43,7 @@ class DebrilRssAtomExtension extends Extension
                     'debril_rss_atom.date_formats', array_merge($default, $config['date_formats'])
             );
         }
+
+        $container->setParameter('debril_rss_atom.private_feeds', $config['private']);
     }
 }

--- a/README.md
+++ b/README.md
@@ -224,6 +224,18 @@ Need to keep the existing routes and add one mapped to a different FeedProvider 
 
 The `source` parameter must contain a valid service name defined in your application.
 
+Private feeds
+-------------
+
+You may have private feeds, user-specific or behind some authentication.  
+In that case, you don't want to `Cache-Control: public` header to be added, not to have your feed cached by a reverse-proxy (such as Symfony2 AppCache or Varnish).  
+You can do so by setting `private` parameter to `false` in config:
+
+```yml
+debril_rss_atom:
+    private: true
+```
+
 Contributors
 ------------
 


### PR DESCRIPTION
It may be needed to have "private" feeds: they could require some kind of authentication, usually HTTP auth, to be user-specific or subscription-users only.

In those cases, setting a `Cache-Control: public` header would cause those private data to be leaked in any cache, reverse-proxy, such as Symfony2 AppCache or Varnish.
In there I add a configuration option not to add this header. For simplicity this option is global, common to all feeds.