### PR TITLE
Fixed typo in README/private

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Private feeds
 
 You may have private feeds, user-specific or behind some authentication.  
 In that case, you don't want to `Cache-Control: public` header to be added, not to have your feed cached by a reverse-proxy (such as Symfony2 AppCache or Varnish).  
-You can do so by setting `private` parameter to `false` in config:
+You can do so by setting `private` parameter to `true` in config:
 
 ```yml
 debril_rss_atom:


### PR DESCRIPTION
Hi,

In the "private" section of README I did a typo, now it is fixed!
