### PR TITLE
Supporting Yahoo media extension

### DIFF
--- a/Protocol/Parser/RssParser.php
+++ b/Protocol/Parser/RssParser.php
@@ -66,12 +66,12 @@ class RssParser extends Parser
                 $date = self::convertToDateTime($xmlElement->pubDate, $format);
             }
             $item->setTitle($xmlElement->title)
-                 ->setDescription($xmlElement->description)
-                 ->setPublicId($xmlElement->guid)
-                 ->setUpdated($date)
-                 ->setLink($xmlElement->link)
-                 ->setComment($xmlElement->comments)
-                 ->setAuthor($xmlElement->author);
+                ->setDescription($xmlElement->description)
+                ->setPublicId($xmlElement->guid)
+                ->setUpdated($date)
+                ->setLink($xmlElement->link)
+                ->setComment($xmlElement->comments)
+                ->setAuthor($xmlElement->author);
 
             if ($date > $latest) {
                 $latest = $date;
@@ -80,6 +80,8 @@ class RssParser extends Parser
             $item->setAdditional($this->getAdditionalNamespacesElements($xmlElement, $namespaces));
 
             $this->handleEnclosure($xmlElement, $item);
+
+            $this->handleMediaExtension($xmlElement, $item);
 
             $this->addValidItem($feed, $item, $filters);
         }
@@ -132,5 +134,24 @@ class RssParser extends Parser
         }
 
         return $this;
+    }
+
+    /**
+     * Parse elements from Yahoo RSS Media extension
+     *
+     * @param SimpleXMLElement $xmlElement
+     * @param ItemInInterface $item with Media added
+     */
+    protected function handleMediaExtension(SimpleXMLElement $xmlElement, ItemInInterface $item)
+    {
+        foreach ($xmlElement->children('http://search.yahoo.com/mrss/') as $xmlMedia) {
+            $media = new Media();
+            $media->setUrl($this->getAttributeValue($xmlMedia, 'url'))
+                ->setType($this->searchAttributeValue($xmlMedia, array('type', 'medium')))
+                ->setLength($this->getAttributeValue($xmlMedia, 'fileSize'))
+            ;
+
+            $item->addMedia($media);
+        }
     }
 }

--- a/Resources/sample-rss-media.xml
+++ b/Resources/sample-rss-media.xml
@@ -16,6 +16,7 @@
             <pubDate>Mon, 06 Sep 2009 16:45:00 GMT</pubDate>
             <author>John Doe</author>
             <media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="http://media-server.com/image.jpg" height="72" width="72"/>
+            <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Marc</dc:creator>
         </item>
 
     </channel>

--- a/Tests/Protocol/FeedReaderTest.php
+++ b/Tests/Protocol/FeedReaderTest.php
@@ -168,10 +168,22 @@ class FeedReaderTest extends \PHPUnit_Framework_TestCase
         $feed = $this->object->parseBody($response, new Parser\FeedContent());
         $items = $feed->getItems();
         $additional = $items[0]->getAdditional();
-        $additionalAttributes = $additional['media']->thumbnail->attributes();
-        $this->assertEquals('http://media-server.com/image.jpg', $additionalAttributes['url']);
+        $this->assertEquals('Marc', $additional['dc']);
     }
 
+    /**
+     * @covers Debril\RssAtomBundle\Protocol\FeedReader::parseBody
+     */
+    public function testRssYahooMediaExtension()
+    {
+        $url = dirname(__FILE__).'/../../Resources/sample-rss-media.xml';
+        $this->object->addParser(new Parser\RssParser());
+        $response = $this->object->getResponse($url, new \DateTime());
+        $feed = $this->object->parseBody($response, new Parser\FeedContent());
+        $items = $feed->getItems();
+        $media = $items[0]->getMedias();
+        $this->assertEquals('http://media-server.com/image.jpg', $media[0]->getUrl());
+    }
     /**
      * @covers Debril\RssAtomBundle\Protocol\FeedReader::parseBody
      */


### PR DESCRIPTION
Hi,

Last time I worked on medias I worked only on RSS 2.0 and standart Atom medias.
But there is another widely-used format: the Yahoo RSS Media extension.
This PR add supports for this. `media:content` elements are correctly parsed as Media objects.

Not to break BC, we keep those in "additional elements" too.

A test was added.