### PR TITLE
Handling RSS content extension

### DIFF
--- a/Protocol/Parser/RssParser.php
+++ b/Protocol/Parser/RssParser.php
@@ -66,7 +66,6 @@ class RssParser extends Parser
                 $date = self::convertToDateTime($xmlElement->pubDate, $format);
             }
             $item->setTitle($xmlElement->title)
-                 ->setDescription($xmlElement->description)
                  ->setPublicId($xmlElement->guid)
                  ->setUpdated($date)
                  ->setLink($xmlElement->link)
@@ -76,6 +75,8 @@ class RssParser extends Parser
             if ($date > $latest) {
                 $latest = $date;
             }
+
+            $this->handleDescription($xmlElement, $item);
 
             $item->setAdditional($this->getAdditionalNamespacesElements($xmlElement, $namespaces));
 
@@ -132,5 +133,24 @@ class RssParser extends Parser
         }
 
         return $this;
+    }
+
+    /**
+     * According to RSS specs, either we can have a summary in description ;
+     * full content in description ; or a summary in description AND full content in content:encoded
+     *
+     * @param SimpleXMLElement $xmlElement
+     * @param ItemInInterface $item
+     */
+    protected function handleDescription(SimpleXMLElement $xmlElement, ItemInInterface $item)
+    {
+        $contentChild = $xmlElement->children('http://purl.org/rss/1.0/modules/content/');
+
+        if (isset($contentChild->encoded)) {
+            $item->setDescription($contentChild->encoded);
+            $item->setSummary($xmlElement->description);
+        } else {
+            $item->setDescription($xmlElement->description);
+        }
     }
 }

--- a/Resources/sample-rss-content.xml
+++ b/Resources/sample-rss-content.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+    <channel>
+        <title>RSS Title</title>
+        <description>This is an example of an RSS feed</description>
+        <link>http://www.someexamplerssdomain.com/main.html</link>
+        <lastBuildDate>Mon, 06 Sep 2010 00:01:00 GMT</lastBuildDate>
+        <pubDate>Mon, 06 Sep 2009 16:45:00 GMT</pubDate>
+        <ttl>1800</ttl>
+
+        <item>
+            <title>Example entry</title>
+            <description>Here is a short summary...</description>
+            <content:encoded>Here is the real content</content:encoded>
+            <link>http://www.wikipedia.org/</link>
+            <guid>unique string per item</guid>
+            <pubDate>Mon, 06 Sep 2009 16:45:00 GMT</pubDate>
+            <author>John Doe</author>
+            <enclosure url="http://www.scripting.com/mp3s/weatherReportSuite.mp3" length="12216320" type="audio/mpeg" />
+        </item>
+    </channel>
+</rss>

--- a/Tests/Protocol/Parser/RssParserTest.php
+++ b/Tests/Protocol/Parser/RssParserTest.php
@@ -168,4 +168,24 @@ class RssParserTest extends ParserAbstract
         $date = '2003-13T18:30:02Z';
         $this->object->guessDateFormat($date);
     }
+
+    /**
+     * @covers Debril\RssAtomBundle\Protocol\Parser\RssParser::parseBody
+     */
+    public function testParseWithContentExtension()
+    {
+        $file = dirname(__FILE__).'/../../../Resources/sample-rss-content.xml';
+        $xmlBody = new \SimpleXMLElement(file_get_contents($file));
+
+        $date = \DateTime::createFromFormat('Y-m-d', '2005-10-10');
+        $filters = array(new ModifiedSince($date));
+        $feed = $this->object->parse($xmlBody, new FeedContent(), $filters);
+
+        $this->assertGreaterThan(0, $feed->getItemsCount());
+
+        $item = current($feed->getItems());
+
+        $this->assertEquals('Here is a short summary...', $item->getSummary());
+        $this->assertEquals('Here is the real content', $item->getDescription());
+    }
 }


### PR DESCRIPTION
Hi,

That one follows #80 
For BC reasons `content:encoded` is not removed from additional elements.
