### PR TITLE
Parsing categories

### DIFF
--- a/Protocol/CategoryInInterface.php
+++ b/Protocol/CategoryInInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Rss/Atom Bundle for Symfony 2.
+ *
+ *
+ * @license http://opensource.org/licenses/lgpl-3.0.html LGPL
+ * @copyright (c) 2013, Alexandre Debril
+ */
+namespace Debril\RssAtomBundle\Protocol;
+
+/**
+ * Class CategoryInInterface
+ *
+ * Interface used when reading an external feed.
+ */
+interface CategoryInInterface
+{
+    /**
+     * Atom : feed.entry.category <feed><entry><category>
+     * Rss  : rss.channel.item.category[term] <rss><channel><item><category>
+     *
+     * @param string $name
+     *
+     * @return $this
+     */
+    public function setName($name);
+}

--- a/Protocol/CategoryOutInterface.php
+++ b/Protocol/CategoryOutInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Rss/Atom Bundle for Symfony 2.
+ *
+ *
+ * @license http://opensource.org/licenses/lgpl-3.0.html LGPL
+ * @copyright (c) 2013, Alexandre Debril
+ */
+namespace Debril\RssAtomBundle\Protocol;
+
+/**
+ * Interface CategoryOutInterface
+ */
+interface CategoryOutInterface
+{
+    /**
+     * Atom : feed.entry.category <feed><entry><category>
+     * Rss  : rss.channel.item.category[term] <rss><channel><item><category>
+     *
+     * @return string
+     */
+    public function getName();
+}

--- a/Protocol/ItemInInterface.php
+++ b/Protocol/ItemInInterface.php
@@ -85,4 +85,12 @@ interface ItemInInterface
      * @param Media $media
      */
     public function addMedia(Media $media);
+
+    /**
+     * Atom : feed.entry.category <feed><entry><category>
+     * Rss  : rss.channel.item.category[term] <rss><channel><item><category>
+     *
+     * @param CategoryInInterface $category
+     */
+    public function addCategory(CategoryInInterface $category);
 }

--- a/Protocol/ItemOutInterface.php
+++ b/Protocol/ItemOutInterface.php
@@ -86,4 +86,12 @@ interface ItemOutInterface
      * @return \ArrayIterator|MediaOutInterface[] $medias
      */
     public function getMedias();
+
+    /**
+     * Atom : feed.entry.category <feed><entry><category>
+     * Rss  : rss.channel.item.category[term] <rss><channel><item><category>
+     *
+     * @return CategoryOutInterface[]
+     */
+    public function getCategories();
 }

--- a/Protocol/Parser/AtomParser.php
+++ b/Protocol/Parser/AtomParser.php
@@ -80,6 +80,8 @@ class AtomParser extends Parser
             $item->setAdditional($this->getAdditionalNamespacesElements($xmlElement, $namespaces));
             $this->handleEnclosure($xmlElement, $item);
 
+            $this->parseCategories($xmlElement, $item);
+
             $this->addValidItem($feed, $item, $filters);
         }
 
@@ -153,5 +155,22 @@ class AtomParser extends Parser
         }
 
         return $this;
+    }
+
+    /**
+     * Parse category elements.
+     * We may have more than one.
+     *
+     * @param SimpleXMLElement $element
+     * @param ItemInInterface $item
+     */
+    protected function parseCategories(SimpleXMLElement $element, ItemInInterface $item)
+    {
+        foreach ($element->category as $xmlCategory) {
+            $category = new Category();
+            $category->setName($this->getAttributeValue($xmlCategory, 'term'));
+
+            $item->addCategory($category);
+        }
     }
 }

--- a/Protocol/Parser/Category.php
+++ b/Protocol/Parser/Category.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Rss/Atom Bundle for Symfony 2.
+ *
+ *
+ * @license http://opensource.org/licenses/lgpl-3.0.html LGPL
+ * @copyright (c) 2013, Alexandre Debril
+ */
+namespace Debril\RssAtomBundle\Protocol\Parser;
+
+use Debril\RssAtomBundle\Protocol\CategoryInInterface;
+use Debril\RssAtomBundle\Protocol\CategoryOutInterface;
+
+/**
+ * Class Category
+ */
+class Category implements CategoryInInterface, CategoryOutInterface
+{
+    /**
+     * Atom : feed.entry.category <feed><entry><category>
+     * Rss  : rss.channel.item.category[term] <rss><channel><item><category>
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return $this
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/Protocol/Parser/Item.php
+++ b/Protocol/Parser/Item.php
@@ -10,6 +10,7 @@
 namespace Debril\RssAtomBundle\Protocol\Parser;
 
 use DateTime;
+use Debril\RssAtomBundle\Protocol\CategoryInInterface;
 use Debril\RssAtomBundle\Protocol\ItemInInterface;
 use Debril\RssAtomBundle\Protocol\ItemOutInterface;
 
@@ -94,10 +95,16 @@ class Item implements ItemInInterface, ItemOutInterface
     protected $medias;
 
     /**
+     * @var Category[]
+     */
+    protected $categories;
+
+    /**
      * Constructor.
      */
     public function __construct()
     {
+        $this->categories = array();
         $this->medias = new \ArrayIterator();
     }
 
@@ -345,5 +352,25 @@ class Item implements ItemInInterface, ItemOutInterface
     public function getMedias()
     {
         return $this->medias;
+    }
+
+    /**
+     * @param CategoryInInterface $category
+     *
+     * @return $this
+     */
+    public function addCategory(CategoryInInterface $category)
+    {
+        $this->categories[] = $category;
+
+        return $this;
+    }
+
+    /**
+     * @return Category[]
+     */
+    public function getCategories()
+    {
+        return $this->categories;
     }
 }

--- a/Protocol/Parser/RssParser.php
+++ b/Protocol/Parser/RssParser.php
@@ -77,6 +77,8 @@ class RssParser extends Parser
                 $latest = $date;
             }
 
+            $this->parseCategories($xmlElement, $item);
+
             $item->setAdditional($this->getAdditionalNamespacesElements($xmlElement, $namespaces));
 
             $this->handleEnclosure($xmlElement, $item);
@@ -132,5 +134,22 @@ class RssParser extends Parser
         }
 
         return $this;
+    }
+
+    /**
+     * Parse category elements.
+     * We may have more than one.
+     *
+     * @param SimpleXMLElement $element
+     * @param ItemInInterface $item
+     */
+    protected function parseCategories(SimpleXMLElement $element, ItemInInterface $item)
+    {
+        foreach ($element->category as $xmlCategory) {
+            $category = new Category();
+            $category->setName((string) $xmlCategory);
+
+            $item->addCategory($category);
+        }
     }
 }

--- a/Resources/sample-atom.xml
+++ b/Resources/sample-atom.xml
@@ -22,11 +22,13 @@
             <div>A title</div>
             <p>A paragraph</p>
         </content>
+        <category term="Category1" />
         <author>
             <name>John Doe</name>
             <email>johndoe@example.com</email>
             <uri>http://johndoe.com</uri>
         </author>
+        <category term="Category2" />
     </entry>
 
     <entry>
@@ -39,5 +41,4 @@
             <p>A paragraph</p>
         </content>
     </entry>
-
 </feed>

--- a/Resources/sample-rss.xml
+++ b/Resources/sample-rss.xml
@@ -15,8 +15,9 @@
             <guid>unique string per item</guid>
             <pubDate>Mon, 06 Sep 2009 16:45:00 GMT</pubDate>
             <author>John Doe</author>
+            <category>Category1</category>
             <enclosure url="http://www.scripting.com/mp3s/weatherReportSuite.mp3" length="12216320" type="audio/mpeg" />
+            <category>Category2</category>
         </item>
-
     </channel>
 </rss>

--- a/Tests/Protocol/Parser/AtomParserTest.php
+++ b/Tests/Protocol/Parser/AtomParserTest.php
@@ -107,6 +107,12 @@ class AtomParserTest extends ParserAbstract
         }
 
         $this->assertEquals(1, $count);
+
+        $categories = $item->getCategories();
+        $this->assertCount(2, $categories);
+        $this->assertInstanceOf('Debril\RssAtomBundle\Protocol\Parser\Category', $categories[0]);
+        $this->assertEquals('Category1', $categories[0]->getName());
+        $this->assertEquals('Category2', $categories[1]->getName());
     }
 
     /**

--- a/Tests/Protocol/Parser/RssParserTest.php
+++ b/Tests/Protocol/Parser/RssParserTest.php
@@ -99,6 +99,12 @@ class RssParserTest extends ParserAbstract
         }
 
         $this->assertEquals(1, $count);
+
+        $categories = $item->getCategories();
+        $this->assertCount(2, $categories);
+        $this->assertInstanceOf('Debril\RssAtomBundle\Protocol\Parser\Category', $categories[0]);
+        $this->assertEquals('Category1', $categories[0]->getName());
+        $this->assertEquals('Category2', $categories[1]->getName());
     }
 
     /**


### PR DESCRIPTION
Hi,

I've added parser support for Categories, both in RSS and Atom.
`Item` now has an array of `Category` objects. I had to "level by RSS", Atom has way more attributes so I'm sticking only to the name/term.
Some tests have been added. Later exporting categories could be easily added.