### PR TITLE
Fix: attributes are casted to strings

### DIFF
--- a/Protocol/Parser.php
+++ b/Protocol/Parser.php
@@ -298,7 +298,7 @@ abstract class Parser
         $attributes = $element[0]->attributes();
         foreach ($attributes as $name => $value) {
             if (strcasecmp($name, $attributeName) === 0) {
-                return $value;
+                return (string) $value;
             }
         }
 
@@ -333,7 +333,7 @@ abstract class Parser
         foreach ($names as $name) {
             $value = $this->getAttributeValue($element, $name);
             if (!is_null($value)) {
-                return $value;
+                return (string) $value;
             }
         }
 


### PR DESCRIPTION
Hi,

Under some cases, `getAttributeValue` and `searchAttributeValue` will return a `SimpleXMLElement` in place of a string.
Such an element casted to a string equals its values, so you want not see that one in tests (PHPUnit `assertEquals` does a loose check).
In there I just make sure we always return a string if we find a value.