### PR TITLE
Handling Dublin Core creator elements

### DIFF
--- a/Protocol/Parser/RssParser.php
+++ b/Protocol/Parser/RssParser.php
@@ -70,8 +70,7 @@ class RssParser extends Parser
                  ->setPublicId($xmlElement->guid)
                  ->setUpdated($date)
                  ->setLink($xmlElement->link)
-                 ->setComment($xmlElement->comments)
-                 ->setAuthor($xmlElement->author);
+                 ->setComment($xmlElement->comments);
 
             if ($date > $latest) {
                 $latest = $date;
@@ -79,12 +78,12 @@ class RssParser extends Parser
 
             $this->parseCategories($xmlElement, $item);
 
+            $this->handleAuthor($xmlElement, $item);
             $this->handleDescription($xmlElement, $item);
 
             $item->setAdditional($this->getAdditionalNamespacesElements($xmlElement, $namespaces));
 
             $this->handleEnclosure($xmlElement, $item);
-
             $this->handleMediaExtension($xmlElement, $item);
 
             $this->addValidItem($feed, $item, $filters);
@@ -192,6 +191,25 @@ class RssParser extends Parser
             $category->setName((string) $xmlCategory);
 
             $item->addCategory($category);
+        }
+    }
+
+    /**
+     * Parse author:
+     * first we look at optional dc:creator, which is the author name
+     * if no, we fallback to the RSS author element which is the author email
+     *
+     * @param SimpleXMLElement $element
+     * @param ItemInInterface $item
+     */
+    protected function handleAuthor(SimpleXMLElement $element, ItemInInterface $item)
+    {
+        $dcChild = $element->children('http://purl.org/dc/elements/1.1/');
+
+        if (isset($dcChild->creator)) {
+            $item->setAuthor((string) $dcChild->creator);
+        } else {
+            $item->setAuthor((string) $element->author);
         }
     }
 }

--- a/Resources/sample-rss-creator.xml
+++ b/Resources/sample-rss-creator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<rss version="2.0">
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
     <channel>
         <title>RSS Title</title>
         <description>This is an example of an RSS feed</description>
@@ -15,6 +15,7 @@
             <guid>unique string per item</guid>
             <pubDate>Mon, 06 Sep 2009 16:45:00 GMT</pubDate>
             <author>john.doe@mail.com</author>
+            <dc:creator>John Doe</dc:creator>
             <category>Category1</category>
             <enclosure url="http://www.scripting.com/mp3s/weatherReportSuite.mp3" length="12216320" type="audio/mpeg" />
             <category>Category2</category>

--- a/Tests/Protocol/Parser/RssParserTest.php
+++ b/Tests/Protocol/Parser/RssParserTest.php
@@ -89,7 +89,7 @@ class RssParserTest extends ParserAbstract
 
         $item = current($feed->getItems());
         $this->assertInternalType('string', $item->getAuthor());
-        $this->assertEquals('John Doe', $item->getAuthor());
+        $this->assertEquals('john.doe@mail.com', $item->getAuthor());
 
         $medias = $item->getMedias();
         $count = 0;
@@ -193,5 +193,25 @@ class RssParserTest extends ParserAbstract
 
         $this->assertEquals('Here is a short summary...', $item->getSummary());
         $this->assertEquals('Here is the real content', $item->getDescription());
+    }
+
+    /**
+     * @covers Debril\RssAtomBundle\Protocol\Parser\RssParser::parseBody
+     */
+    public function testParseWithDublinCoreExtension()
+    {
+        $file = dirname(__FILE__).'/../../../Resources/sample-rss-creator.xml';
+        $xmlBody = new \SimpleXMLElement(file_get_contents($file));
+
+        $date = \DateTime::createFromFormat('Y-m-d', '2005-10-10');
+        $filters = array(new ModifiedSince($date));
+        $feed = $this->object->parse($xmlBody, new FeedContent(), $filters);
+
+        $this->assertGreaterThan(0, $feed->getItemsCount());
+
+        $item = current($feed->getItems());
+
+        $this->assertInternalType('string', $item->getAuthor());
+        $this->assertEquals('John Doe', $item->getAuthor());
     }
 }


### PR DESCRIPTION
Hi,

At the moment there is a small inconsistency: the `Item::author` property should receive the author name.
That)s working OK with Atom, but not that much with RSS, because RSS specs says `<author>` contains the author email address.
To face it, the Dublin Core extension was added with a `<dc:creator>` element.

With this PR, we check if the DC extension is used when parsing RSS, if so we take the creator name. Otherwise we fall back to the author RSS element.
In all cases, in RSS those elements are all optionals.