### PR TITLE
Triming date

### DIFF
--- a/Protocol/Parser/RssParser.php
+++ b/Protocol/Parser/RssParser.php
@@ -61,10 +61,14 @@ class RssParser extends Parser
         $date = new \DateTime('now');
         foreach ($xmlBody->channel->item as $xmlElement) {
             $item = $this->newItem();
+
             if (isset($xmlElement->pubDate)) {
-                $format = isset($format) ? $format : $this->guessDateFormat($xmlElement->pubDate);
-                $date = self::convertToDateTime($xmlElement->pubDate, $format);
+                $readDate = trim($xmlElement->pubDate);
+
+                $format = isset($format) ? $format : $this->guessDateFormat($readDate);
+                $date = self::convertToDateTime($readDate, $format);
             }
+
             $item->setTitle($xmlElement->title)
                  ->setDescription($xmlElement->description)
                  ->setPublicId($xmlElement->guid)


### PR DESCRIPTION
Hi,

In some poorly-formed RSS feed there is some space around date strings.
Php date functions will fail then. I propose there to `trim()` date read from RSS files.
There should be no BC or edge cases.