### PR TITLE
Added configurable driver

### DIFF
--- a/DebrilRssAtomBundle.php
+++ b/DebrilRssAtomBundle.php
@@ -2,8 +2,16 @@
 
 namespace Debril\RssAtomBundle;
 
+use Debril\RssAtomBundle\DependencyInjection\CompilerPass\DriverCompilerPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class DebrilRssAtomBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new DriverCompilerPass());
+    }
 }

--- a/DependencyInjection/CompilerPass/DriverCompilerPass.php
+++ b/DependencyInjection/CompilerPass/DriverCompilerPass.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Debril\RssAtomBundle\DependencyInjection\CompilerPass;
+
+use Debril\RssAtomBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Class DriverCompilerPass
+ */
+class DriverCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $configs = $container->getExtensionConfig('debril_rss_atom');
+
+        $configTree = new Configuration();
+        $processor = new Processor();
+        $config = $processor->processConfiguration($configTree, $configs);
+
+        switch ($config['driver']) {
+            case 'curl':
+                // nothing to do
+                break;
+            case 'file':
+                $container
+                    ->getDefinition('debril.reader')
+                    ->replaceArgument(0, new Reference('debril.file'));
+
+                break;
+            case 'guzzle':
+                if (! isset($config['driver_service'])) {
+                    throw new \Exception('When setting debril_rss_atom.driver to "guzzle", you should provide Client service ID in debril_rss_atom.driver_service!');
+                }
+
+                $guzzlebridge = $container->getDefinition('debril.http.guzzle_bridge');
+                $guzzlebridge->addArgument(new Reference($config['driver_service']));
+
+                $container
+                    ->getDefinition('debril.reader')
+                    ->replaceArgument(0, $guzzlebridge);
+                break;
+            case 'service':
+                if (! isset($config['driver_service'])) {
+                    throw new \Exception('When setting debril_rss_atom.driver to "service", you should provide service ID in debril_rss_atom.driver_service!');
+                }
+
+                $container
+                    ->getDefinition('debril.reader')
+                    ->replaceArgument(0, new Reference($config['driver_service']));
+                break;
+            default:
+                throw new \Exception('Unable to handle debril_rss_atom.driver value!');
+        }
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,6 +28,14 @@ class Configuration implements ConfigurationInterface
                     ->arrayNode('date_formats')
                         ->prototype('scalar')->end()
                     ->end()
+                    ->enumNode('driver')
+                        ->info('Driver to use to fetch RSS feed. Valid values are "curl" (default), "file", "guzzle", "service".')
+                        ->values(array('curl', 'file', 'guzzle', 'service'))
+                        ->defaultValue('curl')
+                    ->end()
+                    ->scalarNode('driver_service')
+                        ->info('If driver is set to "csa-guzzle" or "service", the ID of the service to use')
+                    ->end()
                 ->end()
         ;
 

--- a/Driver/GuzzleBridgeDriver.php
+++ b/Driver/GuzzleBridgeDriver.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Debril\RssAtomBundle\Driver;
+
+use GuzzleHttp\Client;
+
+/**
+ * Class GuzzleBridgeDriver
+ */
+class GuzzleBridgeDriver implements HttpDriverInterface
+{
+    /**
+     * @var Client
+     */
+    private $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @param string    $url
+     * @param \DateTime $lastModified
+     *
+     * @return HttpDriverResponse
+     */
+    public function getResponse($url, \DateTime $lastModified)
+    {
+        $ressource = $this->client->request('GET', $url);
+
+        $response = new HttpDriverResponse();
+        $response->setHttpCode($ressource->getStatusCode());
+        $response->setHttpVersion($ressource->getProtocolVersion());
+        $response->setHttpMessage($ressource->getReasonPhrase());
+        $response->setHeaders($ressource->getHeaders());
+        $response->setBody($ressource->getBody());
+
+        return $response;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -236,6 +236,36 @@ debril_rss_atom:
     private: true
 ```
 
+Using Guzzle
+------------
+
+Instead of the provided Curl-based driver, you may choose to use a different driver to fetch the RSS feed.
+Then change the configuration:
+
+```yml
+# app/config/config.yml
+debril_rss_atom:
+    driver: curl
+```
+
+Options are:
+
+ * `curl` (default): use a basic CURL-based driver with default options
+ * `file`: will read from a locale file (for tests)
+ * `guzzle`: use a GuzzleClient declared as a service - see below
+ * `service`: use any service that implements `HttpDriverInterface`
+ 
+For the 2 last options, you need to pass the ID of the service you want to use:
+
+```yml
+# app/config/config.yml
+debril_rss_atom:
+    driver: guzzle
+    driver_service: my_guzzle_client_service_id
+```
+
+To easily declare Guzzle clients as Symfony2 services, [CsaGuzzleBundle](https://github.com/csarrazi/CsaGuzzleBundle) may come useful to you.
+
 Contributors
 ------------
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -15,6 +15,8 @@
         <parameter key="debril.formatter.rss.class">Debril\RssAtomBundle\Protocol\Formatter\FeedRssFormatter</parameter>
         <parameter key="debril.formatter.atom.class">Debril\RssAtomBundle\Protocol\Formatter\FeedAtomFormatter</parameter>
         <parameter key="debril.http.curl.class">Debril\RssAtomBundle\Driver\HttpCurlDriver</parameter>
+        <parameter key="debril.http.guzzle_bridge.class">Debril\RssAtomBundle\Driver\GuzzleBridgeDriver</parameter>
+        <parameter key="debril.file.class">Debril\RssAtomBundle\Driver\FileDriver</parameter>
         <parameter key="debril.provider.mock.class">Debril\RssAtomBundle\Provider\MockProvider</parameter>
         <parameter key="debril.provider.default.class">Debril\RssAtomBundle\Provider\MockProvider</parameter>
         <parameter key="debril.provider.doctrine.class">Debril\RssAtomBundle\Provider\DoctrineFeedContentProvider</parameter>
@@ -37,6 +39,9 @@
         </service>
 
         <service id="debril.http.curl" class="%debril.http.curl.class%" />
+        <service id="debril.http.guzzle_bridge" class="%debril.http.guzzle_bridge.class%" />
+        <service id="debril.file" class="%debril.file.class%" />
+
         <service id="debril.parser.factory" class="%debril.parser.factory.class%">
             <call method="setFeedClass">
                 <argument>%debril.parser.feed.class%</argument>
@@ -47,7 +52,7 @@
         </service>
 
         <service id="debril.reader" class="%debril.reader.class%">
-            <argument type="service" id="debril.http.curl"/>
+            <argument type="service" id="debril.http.curl"/><!-- ID may be changed by Extension -->
             <argument type="service" id="debril.parser.factory"/>
             <call method="addParser">
                 <argument type="service" id="debril.parser.rss" />

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
         "symfony/form": "~2.6",
         "symfony/browser-kit": "~2.6"
     },
+    "suggest": {
+        "guzzlehttp/guzzle": "We can use Guzzle >= 6.0 to fetch feed - set 'driver' to 'guzzle' then"
+    },
     "autoload": {
         "psr-0": {
             "Debril\\RssAtomBundle": ""


### PR DESCRIPTION
Hi,

Something I missed so far is the ability to customize how the request is made about headers, time out, and so on.
This PR introduces 2 new configuration options:

```yml
debril_rss_atom:
    driver: guzzle
    driver_service: my_guzzle_client_service_id
```

Driver is by default curl, and then falls back to the current driver. 
But it can be changed to `service`, where you can use your own service (it was possible before, but you need to decorate services...) ; or to `guzzle`, then you can use any Guzzle client. 
In that case you have full control over the request options, and that's particularly nice to use with CsaGuzzleBundle which allows you to create Guzzle clients through `config.yml`. Though we are not especially dependent on that bundle. 

I could not think of good integration tests to add. I will tests it manually on some project I have, but i'm listening to any feedback on those.