### PR TITLE
Easier to override parsers

### DIFF
--- a/Protocol/Parser.php
+++ b/Protocol/Parser.php
@@ -220,7 +220,7 @@ abstract class Parser
             throw new ParserException("date is the wrong format : {$string} - expected {$format}");
         }
 
-        $date->setTimezone(self::getSystemTimezone());
+        $date->setTimezone(static::getSystemTimezone());
 
         return $date;
     }
@@ -232,11 +232,11 @@ abstract class Parser
      */
     public static function getSystemTimezone()
     {
-        if (is_null(self::$timezone)) {
-            self::$timezone = new \DateTimeZone(date_default_timezone_get());
+        if (is_null(static::$timezone)) {
+            static::$timezone = new \DateTimeZone(date_default_timezone_get());
         }
 
-        return self::$timezone;
+        return static::$timezone;
     }
 
     /**
@@ -244,7 +244,7 @@ abstract class Parser
      */
     public static function resetTimezone()
     {
-        self::$timezone = null;
+        static::$timezone = null;
     }
 
     /**

--- a/Protocol/Parser/AtomParser.php
+++ b/Protocol/Parser/AtomParser.php
@@ -69,7 +69,7 @@ class AtomParser extends Parser
                     ->setPublicId($xmlElement->id)
                     ->setSummary($this->parseContent($xmlElement->summary))
                     ->setDescription($this->parseContent($xmlElement->content))
-                    ->setUpdated(self::convertToDateTime($xmlElement->updated, $itemFormat));
+                    ->setUpdated(static::convertToDateTime($xmlElement->updated, $itemFormat));
 
             $item->setLink($this->detectLink($xmlElement, 'alternate'));
 
@@ -103,7 +103,7 @@ class AtomParser extends Parser
         $feed->setDescription($xmlBody->subtitle);
 
         $format = $this->guessDateFormat($xmlBody->updated);
-        $updated = self::convertToDateTime($xmlBody->updated, $format);
+        $updated = static::convertToDateTime($xmlBody->updated, $format);
         $feed->setLastModified($updated);
     }
 

--- a/Protocol/Parser/RdfParser.php
+++ b/Protocol/Parser/RdfParser.php
@@ -58,7 +58,7 @@ class RdfParser extends Parser
 
         if (isset($xmlBody->channel->date)) {
             $date = $xmlBody->channel->children('dc', true);
-            $updated = self::convertToDateTime($date[0], $this->guessDateFormat($date[0]));
+            $updated = static::convertToDateTime($date[0], $this->guessDateFormat($date[0]));
             $feed->setLastModified($updated);
         }
 
@@ -70,7 +70,7 @@ class RdfParser extends Parser
 
             $item->setTitle($xmlElement->title)
                     ->setDescription($xmlElement->description)
-                    ->setUpdated(self::convertToDateTime($date[0], $format))
+                    ->setUpdated(static::convertToDateTime($date[0], $format))
                     ->setLink($xmlElement->link);
 
             $this->addValidItem($feed, $item, $filters);

--- a/Protocol/Parser/RssParser.php
+++ b/Protocol/Parser/RssParser.php
@@ -66,7 +66,7 @@ class RssParser extends Parser
                 $readDate = trim($xmlElement->pubDate);
 
                 $format = isset($format) ? $format : $this->guessDateFormat($readDate);
-                $date = self::convertToDateTime($readDate, $format);
+                $date = static::convertToDateTime($readDate, $format);
             }
 
             $item->setTitle($xmlElement->title)
@@ -121,7 +121,7 @@ class RssParser extends Parser
     protected function setLastModified(FeedInterface $feed, $rssDate)
     {
         $format = $this->guessDateFormat($rssDate);
-        $updated = self::convertToDateTime($rssDate, $format);
+        $updated = static::convertToDateTime($rssDate, $format);
         $feed->setLastModified($updated);
     }
 


### PR DESCRIPTION
Hi,

In parsers, `self` was used a lot. Static methods called this way can not be overridden: `self` will always resolve to the original class.
In this PR, those calls are replaced with `static`, which is resolved to the calling class ([more info](http://php.net/manual/fr/language.oop5.late-static-bindings.php))
No BC break.