### PR TITLE
Fix deprecation in Configuration tree builder with BC for Symfony <4.2

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Debril\RssAtomBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -17,9 +18,17 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder() : TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('debril_rss_atom');
 
-        $treeBuilder->root('debril_rss_atom')
+        // For BC with symfony/config < 4.2
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            /** @var ArrayNodeDefinition $rootNode */
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('debril_rss_atom');
+        }
+
+        $rootNode
                 ->children()
                     ->booleanNode('private')
                         ->info('Change cache headers so the RSS feed is not cached by public caches (like reverse-proxies...).')


### PR DESCRIPTION
This fixes the `A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.` and `The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "debril_rss_atom" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.` deprecations in a backward compatible way.