### PR TITLE
Allow Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     ],
     "require": {
         "php": ">=7.1",
-        "symfony/config": "~3.4|~4.0",
-        "symfony/http-foundation": "~3.4|~4.0",
-        "symfony/http-kernel": "~3.4|~4.0",
-        "symfony/dependency-injection": "~3.4|~4.0",
+        "symfony/config": "~3.4|~4.0|^5.0",
+        "symfony/http-foundation": "~3.4|~4.0|^5.0",
+        "symfony/http-kernel": "~3.4|~4.0|^5.0",
+        "symfony/dependency-injection": "~3.4|~4.0|^5.0",
         "debril/feed-io": "~3.0|~4.0"
     },
     "require-dev": {
@@ -25,8 +25,8 @@
         "symfony/validator": ">3.0",
         "symfony/finder": ">3.0",
         "symfony/browser-kit": ">3.0",
-        "symfony/yaml": "^4.0",
-        "symfony/framework-bundle": "^4.3"
+        "symfony/yaml": "^4.0|^5.0",
+        "symfony/framework-bundle": "^4.3|^5.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
There may also be something in the service definition for Symfony 5 (autowiring), but this might be enough to at least install the bundle with Symfony 5.