### PR TITLE
Fix Composer Deprecations

### DIFF
--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Debril\RssAtomBundle\DependencyInjection;
+namespace Debril\RssAtomBundle\Tests\DependencyInjection;
 
+use Debril\RssAtomBundle\DependencyInjection\Configuration;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurationTest extends TestCase

--- a/Tests/Provider/MockProviderTest.php
+++ b/Tests/Provider/MockProviderTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Debril\RssAtomBundle\Provider;
+namespace Debril\RssAtomBundle\Tests\Provider;
 
+use Debril\RssAtomBundle\Provider\MockProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/Tests/Request/ModifiedSinceTest.php
+++ b/Tests/Request/ModifiedSinceTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
-namespace Tests\Request;
-
+namespace Debril\RssAtomBundle\Tests\Request;
 
 use Debril\RssAtomBundle\Request\ModifiedSince;
 use PHPUnit\Framework\TestCase;

--- a/Tests/Response/FeedBuilderTest.php
+++ b/Tests/Response/FeedBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Response;
+namespace Debril\RssAtomBundle\Tests\Response;
 
 use Debril\RssAtomBundle\Request\ModifiedSince;
 use Debril\RssAtomBundle\Response\FeedBuilder;

--- a/Tests/Response/HeadersBuilderTest.php
+++ b/Tests/Response/HeadersBuilderTest.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types=1);
 
-
-namespace Tests\Response;
-
+namespace Debril\RssAtomBundle\Tests\Response;
 
 use Debril\RssAtomBundle\Response\HeadersBuilder;
 use PHPUnit\Framework\TestCase;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,10 +17,10 @@
         <whitelist>
             <directory>./</directory>
             <exclude>
+                <directory>./DependencyInjection</directory>
                 <directory>./Resources</directory>
                 <directory>./Tests</directory>
                 <directory>./vendor</directory>
-		<directory>./DependencyInjection</directory>
             </exclude>
         </whitelist>
     </filter>


### PR DESCRIPTION
```
Deprecation Notice: Class Debril\RssAtomBundle\DependencyInjection\ConfigurationTest located in vendor/debril/rss-atom-bundle\Debril\RssAtomBundle\Tests\DependencyInjection\ConfigurationTest.php does not comply with psr-0 autoloading
standard. It will not autoload anymore in Composer v2.0. in phar://composer.phar/src/Composer/Autoload/ClassMapGenerator.php:185
Deprecation Notice: Class Debril\RssAtomBundle\Provider\MockProviderTest located in vendor/debril/rss-atom-bundle\Debril\RssAtomBundle\Tests\Provider\MockProviderTest.php does not comply with psr-0 autoloading standard. It will not au
toload anymore in Composer v2.0. in phar://composer.phar/src/Composer/Autoload/ClassMapGenerator.php:185
```