### PR TITLE
fix deprecations

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,20 +1,20 @@
 feed_stream:
     path: /stream/{format}/{id}
-    defaults: { _controller: DebrilRssAtomBundle:Stream:index, format: 'rss' }
+    defaults: { _controller: Debril\RssAtomBundle\Controller\StreamController::indexAction, format: 'rss' }
     requirements: { "format": "rss|atom|json" }
     
 feed_rss:
     path: /rss/{id}
-    defaults: { _controller: DebrilRssAtomBundle:Stream:index, "format": 'rss', "id": null }
+    defaults: { _controller: Debril\RssAtomBundle\Controller\StreamController::indexAction, "format": 'rss', "id": null }
     
 feed_atom:
     path: /atom/{id}
-    defaults: { _controller: DebrilRssAtomBundle:Stream:index, "format": 'atom', "id": null }
+    defaults: { _controller: Debril\RssAtomBundle\Controller\StreamController::indexAction, "format": 'atom', "id": null }
 
 feed_json:
     path: /json/{id}
-    defaults: { _controller: DebrilRssAtomBundle:Stream:index, "format": 'json', "id": null }
+    defaults: { _controller: Debril\RssAtomBundle\Controller\StreamController::indexAction, "format": 'json', "id": null }
 
 feed_mock:
     path: /mock/rss/{id}
-    defaults: { _controller: DebrilRssAtomBundle:Stream:index, "format": 'rss', "id": null }
+    defaults: { _controller: Debril\RssAtomBundle\Controller\StreamController::indexAction, "format": 'rss', "id": null }

--- a/Tests/Controller/App/routing.xml
+++ b/Tests/Controller/App/routing.xml
@@ -5,14 +5,14 @@
         xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="debril_rss_atom_mock_rss" path="/mock/rss/{id}">
-        <default key="_controller">DebrilRssAtomBundle:Stream:index</default>
+        <default key="_controller">Debril\RssAtomBundle\Controller\StreamController::indexAction</default>
         <default key="format">rss</default>
         <default key="source">debril.provider.mock</default>
         <default key="id">null</default>
     </route>
 
     <route id="debril_rss_atom_bad_provider" path="/bad/provider">
-        <default key="_controller">DebrilRssAtomBundle:Stream:index</default>
+        <default key="_controller">Debril\RssAtomBundle\Controller\StreamController::indexAction</default>
         <default key="format">rss</default>
         <default key="source">debril.parser.rss</default>
         <default key="id">null</default>

--- a/Tests/Controller/App/routing.yml
+++ b/Tests/Controller/App/routing.yml
@@ -1,20 +1,20 @@
 feed_stream:
     path: /stream/{format}/{id}
-    defaults: { _controller: DebrilRssAtomBundle:Stream:index, format: 'rss' }
+    defaults: { _controller: Debril\RssAtomBundle\Controller\StreamController::indexAction, format: 'rss' }
     requirements: { "format": "rss|atom|json" }
     
 feed_rss:
     path: /rss/{id}
-    defaults: { _controller: DebrilRssAtomBundle:Stream:index, "format": 'rss', "id": null }
+    defaults: { _controller: Debril\RssAtomBundle\Controller\StreamController::indexAction, "format": 'rss', "id": null }
     
 feed_atom:
     path: /atom/{id}
-    defaults: { _controller: DebrilRssAtomBundle:Stream:index, "format": 'atom', "id": null }
+    defaults: { _controller: Debril\RssAtomBundle\Controller\StreamController::indexAction, "format": 'atom', "id": null }
 
 feed_json:
     path: /json/{id}
-    defaults: { _controller: DebrilRssAtomBundle:Stream:index, "format": 'json', "id": null }
+    defaults: { _controller: Debril\RssAtomBundle\Controller\StreamController::indexAction, "format": 'json', "id": null }
 
 feed_mock:
     path: /mock/rss/{id}
-    defaults: { _controller: DebrilRssAtomBundle:Stream:index, "format": 'rss', "id": null }
+    defaults: { _controller: Debril\RssAtomBundle\Controller\StreamController::indexAction, "format": 'rss', "id": null }


### PR DESCRIPTION
Fix deprecations for Symfony 4.1+

Warning :
`Referencing controllers with DebrilRssAtomBundle:Stream:index is deprecated since Symfony 4.1, use "Debril\RssAtomBundle\Controller\StreamController::indexAction" instead.`