### PR TITLE
Update symfony dependencies to allow version 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     ],
     "require": {
         "php": ">=7.1",
-        "symfony/config": "~3.4|~4.0|^5.0",
-        "symfony/http-foundation": "~3.4|~4.0|^5.0",
-        "symfony/http-kernel": "~3.4|~4.0|^5.0",
-        "symfony/dependency-injection": "~3.4|~4.0|^5.0",
+        "symfony/config": "~3.4|~4.0|^5.0|^6.0",
+        "symfony/http-foundation": "~3.4|~4.0|^5.0|^6.0",
+        "symfony/http-kernel": "~3.4|~4.0|^5.0|^6.0",
+        "symfony/dependency-injection": "~3.4|~4.0|^5.0|^6.0",
         "debril/feed-io": "~3.0|~4.0"
     },
     "require-dev": {
@@ -25,8 +25,8 @@
         "symfony/validator": ">3.0",
         "symfony/finder": ">3.0",
         "symfony/browser-kit": ">3.0",
-        "symfony/yaml": "^4.0|^5.0",
-        "symfony/framework-bundle": "^4.3|^5.0"
+        "symfony/yaml": "^4.0|^5.0|^6.0",
+        "symfony/framework-bundle": "^4.3|^5.0|^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I have tested this against the latest version of symfony (6.0.2) and it works flawlessly. I tested it with php v8.0.14.
There are a few deprecation warnings in feedIo though, all caused by the "Psr\Http\Message\ResponseInterface" and "Psr\Http\Message\StreamInterface". 